### PR TITLE
Reduce warnings count

### DIFF
--- a/KaZip.pas
+++ b/KaZip.pas
@@ -2836,7 +2836,7 @@ procedure TKAZipEntries.CreateFolder(FolderName: string; FolderDate: TDateTime);
 var
 	FN: string;
 begin
-	FN := IncludeTrailingBackslash(FolderName);
+	FN := IncludeTrailingPathDelimiter(FolderName);
 	AddFolderChain(FN, faDirectory, FolderDate);
 	FParent.FIsDirty := True;
 end;
@@ -2849,8 +2849,8 @@ var
 	X: Integer;
 	L: Integer;
 begin
-	FN := ToZipName(IncludeTrailingBackslash(FolderName));
-	NFN := ToZipName(IncludeTrailingBackslash(NewFolderName));
+	FN := ToZipName(IncludeTrailingPathDelimiter(FolderName));
+	NFN := ToZipName(IncludeTrailingPathDelimiter(NewFolderName));
 	L := Length(FN);
 	if IndexOf(NFN) = -1 then
 	begin

--- a/KaZip.pas
+++ b/KaZip.pas
@@ -1477,7 +1477,9 @@ begin
 				CDFile.FileCommentLength := 0;
 				CDFile.DiskNumberStart := 0;
 				CDFile.InternalFileAttributes := LocalFile.VersionNeededToExtract;
+{$WARN SYMBOL_PLATFORM OFF}
 				CDFile.ExternalFileAttributes := faArchive;
+{$WARN SYMBOL_PLATFORM ON}
 				CDFile.RelativeOffsetOfLocalHeader := Poz;
 				CDFile.FileName := LocalFile.FileName;
 				L := Length(CDFile.FileName);
@@ -2364,7 +2366,9 @@ end;
 
 function TKAZipEntries.AddStream(FileName: string; Stream: TStream): TKAZipEntriesEntry;
 begin
+{$WARN SYMBOL_PLATFORM OFF}
 	Result := AddStream(FileName, faArchive, Now, Stream);
+{$WARN SYMBOL_PLATFORM ON}
 end;
 
 function TKAZipEntries.AddFile(FileName, NewFileName: string): TKAZipEntriesEntry;
@@ -2627,6 +2631,7 @@ begin
 		end;
 		if FParent.FApplyAttributes then
 		begin
+{$WARN SYMBOL_PLATFORM OFF}
 			Attr := faArchive;
 			if Item.FCentralDirectoryFile.ExternalFileAttributes and faHidden > 0 then
 				Attr := Attr or faHidden;
@@ -2635,6 +2640,7 @@ begin
 			if Item.FCentralDirectoryFile.ExternalFileAttributes and faReadOnly > 0 then
 				Attr := Attr or faReadOnly;
 			FileSetAttr(FileName, Attr);
+{$WARN SYMBOL_PLATFORM ON}
 		end;
 	end;
 end;
@@ -3740,7 +3746,9 @@ begin
 				stm.Free;
 			end;
 	}
+{$WARN SYMBOL_PLATFORM OFF}
 	Result := Entries.AddEntryThroughStream(FileName, Now, faArchive);
+{$WARN SYMBOL_PLATFORM ON}
 end;
 
 { TCRC32Stream }


### PR DESCRIPTION
1) we use platform-non-specific function IncludeTrailingPathDelimiter instead of IncludeTrailingBackslash
2) we suppress warnings for platform specific consts such as faArchive
